### PR TITLE
Reduce DateTimeFormatter creation

### DIFF
--- a/src/main/java/com/ramusthastudio/plugin/unixtimestamp/settings/AppSettingsConfigurable.java
+++ b/src/main/java/com/ramusthastudio/plugin/unixtimestamp/settings/AppSettingsConfigurable.java
@@ -36,19 +36,15 @@ public class AppSettingsConfigurable implements Configurable {
   @Override
   public boolean isModified() {
     AppSettingsState settings = AppSettingsState.getInstance();
+    boolean modified;
     if (mySettingsComponent.isCustomPatternEnable()) {
-      boolean modified =
-          mySettingsComponent.isAlreadyPreview()
-              && !mySettingsComponent.getCustomPattern().equals(settings.getCustomPattern());
-      modified |= mySettingsComponent.isUtcEnable() != settings.isUtcEnable();
-      modified |= mySettingsComponent.isInlayHintsEnable() != settings.isUtcEnable();
-      modified |= mySettingsComponent.isInlayHintsPlaceEndOfLineEnable() != settings.isInlayHintsPlaceEndOfLineEnable();
-      return modified;
+      modified = mySettingsComponent.isAlreadyPreview()
+          && !mySettingsComponent.getCustomPattern().equals(settings.getCustomPattern());
+    } else {
+      modified = !mySettingsComponent.getSelectedItem().equals(settings.getDateFormatSettings());
     }
-    boolean modified = !mySettingsComponent.getSelectedItem().getValue()
-        .equals(settings.getDefaultLocalFormatter());
     modified |= mySettingsComponent.isUtcEnable() != settings.isUtcEnable();
-    modified |= mySettingsComponent.isInlayHintsEnable() != settings.isUtcEnable();
+    modified |= mySettingsComponent.isInlayHintsEnable() != settings.isInlayHintsEnable();
     modified |= mySettingsComponent.isInlayHintsPlaceEndOfLineEnable() != settings.isInlayHintsPlaceEndOfLineEnable();
     return modified;
   }


### PR DESCRIPTION
DateTimeFormatter.withZone(...) creates a new instance for every hint generated. A single instance can be utilized instead.
Also fix small cut-n-paste bug in AppSettingsState comparison.
@ramustha, thank you